### PR TITLE
Quality of life improvements

### DIFF
--- a/nvim/.config/nvim/init.lua
+++ b/nvim/.config/nvim/init.lua
@@ -30,6 +30,9 @@ vim.keymap.set('n', 'gK', function()
   local new_config = not vim.diagnostic.config().virtual_lines
   vim.diagnostic.config({ virtual_lines = new_config })
 end, { desc = 'Toggle diagnostic virtual_lines' })
+-- Teminal like shortcuts
+vim.keymap.set('n', '<C-a>', '^')
+vim.keymap.set('n', '<C-e>', '$')
 
 -- [[ Settings ]]
 -- Relative line numbers enabled

--- a/nvim/.config/nvim/lua/plugins/telescope.lua
+++ b/nvim/.config/nvim/lua/plugins/telescope.lua
@@ -53,8 +53,8 @@ return {
     vim.keymap.set('n', '<leader>ff', function() builtin.find_files({ hidden = true }) end, { desc = '[F]ind [F]ile' })
     vim.keymap.set('n', '<leader>fw', lga_shortcuts.grep_word_under_cursor, { desc = '[F]ind Current [W]ord' })
     vim.keymap.set('v', '<leader>fw', lga_shortcuts.grep_visual_selection, { desc = '[F]ind Selected [W]ords' })
-    vim.keymap.set('n', '<leader>f/', lgwa, { desc = '[F]ind by [G]rep' })
-    vim.keymap.set('n', '<leader><leader>', builtin.buffers, { desc = 'Vim Buffers' })
+    vim.keymap.set('n', '<leader><leader>', lgwa, { desc = '[F]ind by [G]rep' })
+    vim.keymap.set('n', '<leader>f/', builtin.buffers, { desc = 'Vim Buffers' })
     vim.keymap.set('n', '<leader>f.', builtin.oldfiles, { desc = '[F]ind Recently Closed' })
     vim.keymap.set('n', '<leader>fp', function() builtin.find_files({ cwd = vim.fn.stdpath('config') }) end, { desc = '[F]ind [P]lugin Config' })
   end,

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -17,6 +17,7 @@ set -g status-position top
 ### copy-mode ###
 # Allow clipboard with OSC-52 work, see https://github.com/tmux/tmux/wiki/Clipboard
 set -s set-clipboard on
+set -g allow-passthrough on
 # Use vim keybindings in copy mode
 unbind -T copy-mode-vi MouseDragEnd1Pane
 setw -g mode-keys vi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new Neovim shortcuts in normal mode: use Ctrl+A to move to the beginning of the line and Ctrl+E to move to the end of the line.

- **Improvements**
  - Swapped key bindings in Neovim for buffer list and live grep functions for easier access.
  - Enabled passthrough mode in tmux, allowing certain key sequences to reach underlying applications directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->