### PR TITLE
resume search + fix copy-paste

### DIFF
--- a/aerospace/.aerospace.toml
+++ b/aerospace/.aerospace.toml
@@ -199,3 +199,7 @@ alt-shift-h = ['join-with left', 'mode main']
 alt-shift-j = ['join-with down', 'mode main']
 alt-shift-k = ['join-with up', 'mode main']
 alt-shift-l = ['join-with right', 'mode main']
+
+[[on-window-detected]]
+if.app-id="com.mitchellh.ghostty"
+run=["layout floating", "move-node-to-workspace 1"]

--- a/nvim/.config/nvim/init.lua
+++ b/nvim/.config/nvim/init.lua
@@ -41,16 +41,24 @@ vim.wo.relativenumber = true
 -- Disable swap files
 vim.opt.swapfile = false
 -- Sync system and vim clipboard
-vim.opt.clipboard = 'unnamedplus'
+vim.o.clipboard = "unnamedplus"
+
+local function paste()
+  return {
+    vim.fn.split(vim.fn.getreg(""), "\n"),
+    vim.fn.getregtype(""),
+  }
+end
+
 vim.g.clipboard = {
-  name = 'OSC 52',
+  name = "OSC 52",
   copy = {
-    ['+'] = require('vim.ui.clipboard.osc52').copy('+'),
-    ['*'] = require('vim.ui.clipboard.osc52').copy('*'),
+    ["+"] = require("vim.ui.clipboard.osc52").copy("+"),
+    ["*"] = require("vim.ui.clipboard.osc52").copy("*"),
   },
   paste = {
-    ['+'] = require('vim.ui.clipboard.osc52').paste('+'),
-    ['*'] = require('vim.ui.clipboard.osc52').paste('*'),
+    ["+"] = paste,
+    ["*"] = paste,
   },
 }
 

--- a/nvim/.config/nvim/lua/plugins/telescope.lua
+++ b/nvim/.config/nvim/lua/plugins/telescope.lua
@@ -57,5 +57,6 @@ return {
     vim.keymap.set('n', '<leader>f/', builtin.buffers, { desc = 'Vim Buffers' })
     vim.keymap.set('n', '<leader>f.', builtin.oldfiles, { desc = '[F]ind Recently Closed' })
     vim.keymap.set('n', '<leader>fp', function() builtin.find_files({ cwd = vim.fn.stdpath('config') }) end, { desc = '[F]ind [P]lugin Config' })
+    vim.keymap.set('n', '<leader>fr', builtin.resume, { desc = '[F]ind [R]esume last search' })
   end,
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a custom rule for Ghostty application windows: they now open as floating windows and are moved to workspace 1 automatically.
  - Introduced a new keybinding in Neovim to quickly resume the last Telescope search using <leader>fr.

- **Improvements**
  - Enhanced Neovim clipboard integration for more direct and reliable paste functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->