### PR TITLE
Feature/dotfiles installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,105 @@
-## Installation Manual
-1. Install `stow` using package manager
-2. Install all programs you have/want to apply dotfiles to (e.g. tmux, zsh...)
-3. Pull dotfiles folder into home directory
-4. Run `stow tmux zsh <whatever_else>` from withing the dotfiles directory
-5. Re-source
+# Dotfiles
 
-## Additional Notes
+Personal dotfiles managed with [GNU Stow](https://www.gnu.org/software/stow/). One command to install everything — dependencies included.
 
-### ZSH
-- For `zsh` you have to install `oh-my-zsh`
-- `oh-my-zsh` replaces the `.zshrc` so make sure that your `.zshrc` has not been replaced post installation
-- we are also installing `zsh-autosuggestions` and `zsh-syntax-highlighting` so will need to be installed
-- For tmux you have to install `tpm`
+## Quick Start
 
-(will need to write a script for these to automate)
+```bash
+git clone <repo-url> ~/dotfiles
+cd ~/dotfiles
+
+# Install specific packages
+./install.sh nvim tmux zsh
+
+# Or run with no args for an interactive menu
+./install.sh
+```
+
+That's it. The script handles OS detection, installs dependencies, and symlinks configs to the right places.
+
+## How It Works
+
+Each top-level folder is a **stow package** — its contents mirror your home directory structure. When you run `stow nvim`, it symlinks `nvim/.config/nvim/` → `~/.config/nvim/`.
+
+Each package has a `deps.sh` manifest that declares:
+- **`DEPS`** — system packages to install (via brew/apt/dnf/pacman)
+- **`setup()`** — post-install steps (cloning plugin managers, etc.)
+
+The `install.sh` script orchestrates everything: detects your OS and package manager, installs deps, runs setup, then stows.
+
+## Packages
+
+| Package | What it configures | Key dependencies |
+|---------|-------------------|-----------------|
+| **zsh** | Shell config, oh-my-zsh, vi mode, aliases | zsh, fzf, oh-my-zsh, zsh-autosuggestions, zsh-syntax-highlighting, nvm |
+| **tmux** | Terminal multiplexer, catppuccin theme, vim-style navigation | tmux, tpm (plugin manager) |
+| **nvim** | Neovim with Lazy.nvim, LSP, treesitter, telescope | neovim, ripgrep, fd, gcc, make, node, python3, stylua, prettier |
+| **ghostty** | Ghostty terminal config | ghostty (macOS only) |
+| **aerospace** | Tiling window manager config | aerospace (macOS only) |
+| **hammerspoon** | macOS automation | hammerspoon (macOS only) |
+
+## Usage
+
+```bash
+# Install specific packages with all their dependencies
+./install.sh nvim tmux
+
+# Interactive menu (no args)
+./install.sh
+
+# Remove symlinks for a package
+./install.sh --uninstall nvim
+
+# Re-link after adding new dotfiles to a package
+./install.sh --restow nvim
+```
+
+## Supported Platforms
+
+- **macOS** — uses Homebrew (brew/brew cask)
+- **Linux** — supports apt (Debian/Ubuntu), dnf (Fedora), pacman (Arch)
+
+macOS-only packages (aerospace, ghostty, hammerspoon) skip gracefully on Linux.
+
+## Adding a New Package
+
+1. Create a folder matching the tool name (e.g. `alacritty/`)
+2. Mirror the home directory structure inside it (e.g. `alacritty/.config/alacritty/alacritty.toml`)
+3. Add a `deps.sh` with dependencies and setup:
+
+```bash
+DEPS=(alacritty)
+
+setup() {
+  # Any post-install setup goes here
+  :
+}
+```
+
+4. Run `./install.sh alacritty`
+
+## Structure
+
+```
+~/dotfiles/
+├── install.sh           # Main entry point
+├── lib/common.sh        # OS detection, pkg helpers, logging
+├── zsh/
+│   ├── deps.sh          # Dependencies + setup
+│   └── .zshrc           # → ~/.zshrc
+├── tmux/
+│   ├── deps.sh
+│   └── .tmux.conf       # → ~/.tmux.conf
+├── nvim/
+│   ├── deps.sh
+│   └── .config/nvim/    # → ~/.config/nvim/
+├── aerospace/
+│   ├── deps.sh
+│   └── .config/aerospace/
+├── ghostty/
+│   ├── deps.sh
+│   └── .config/ghostty/
+└── hammerspoon/
+    ├── deps.sh
+    └── .hammerspoon/    # → ~/.hammerspoon/
+```

--- a/aerospace/deps.sh
+++ b/aerospace/deps.sh
@@ -9,6 +9,8 @@ if [[ "$(detect_os)" != "macos" ]]; then
   return 0 2>/dev/null || exit 0
 fi
 
+DESCRIPTION="Tiling window manager for macOS"
+MACOS_ONLY=true
 DEPS=()
 
 setup() {

--- a/aerospace/deps.sh
+++ b/aerospace/deps.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Dependencies for aerospace (macOS only)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../lib/common.sh"
+
+if [[ "$(detect_os)" != "macos" ]]; then
+  log_warn "aerospace is macOS-only, skipping on Linux"
+  return 0 2>/dev/null || exit 0
+fi
+
+DEPS=()
+
+setup() {
+  log_info "Installing AeroSpace via brew cask..."
+  install_cask nikitabobko/tap/aerospace
+}

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# One-liner dotfiles installer:
+#   curl -fsSL https://raw.githubusercontent.com/mudmov/dotfiles/main/bootstrap.sh | bash
+set -euo pipefail
+
+DOTFILES_DIR="$HOME/dotfiles"
+REPO="https://github.com/mudmov/dotfiles.git"
+
+if [ -d "$DOTFILES_DIR" ]; then
+  echo "Dotfiles already cloned at $DOTFILES_DIR, pulling latest..."
+  git -C "$DOTFILES_DIR" pull
+else
+  echo "Cloning dotfiles..."
+  git clone "$REPO" "$DOTFILES_DIR"
+fi
+
+cd "$DOTFILES_DIR"
+chmod +x install.sh
+exec ./install.sh "$@"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,13 +5,15 @@ set -euo pipefail
 
 DOTFILES_DIR="$HOME/dotfiles"
 REPO="https://github.com/mudmov/dotfiles.git"
+BRANCH="${DOTFILES_BRANCH:-main}"
 
 if [ -d "$DOTFILES_DIR" ]; then
   echo "Dotfiles already cloned at $DOTFILES_DIR, pulling latest..."
+  git -C "$DOTFILES_DIR" checkout "$BRANCH"
   git -C "$DOTFILES_DIR" pull
 else
-  echo "Cloning dotfiles..."
-  git clone "$REPO" "$DOTFILES_DIR"
+  echo "Cloning dotfiles (branch: $BRANCH)..."
+  git clone -b "$BRANCH" "$REPO" "$DOTFILES_DIR"
 fi
 
 cd "$DOTFILES_DIR"

--- a/ghostty/deps.sh
+++ b/ghostty/deps.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Dependencies for ghostty (macOS only)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../lib/common.sh"
+
+if [[ "$(detect_os)" != "macos" ]]; then
+  log_warn "ghostty is macOS-only, skipping on Linux"
+  return 0 2>/dev/null || exit 0
+fi
+
+DEPS=()
+
+setup() {
+  log_info "Installing Ghostty via brew cask..."
+  install_cask ghostty
+}

--- a/ghostty/deps.sh
+++ b/ghostty/deps.sh
@@ -9,6 +9,8 @@ if [[ "$(detect_os)" != "macos" ]]; then
   return 0 2>/dev/null || exit 0
 fi
 
+DESCRIPTION="GPU-accelerated terminal emulator"
+MACOS_ONLY=true
 DEPS=()
 
 setup() {

--- a/hammerspoon/deps.sh
+++ b/hammerspoon/deps.sh
@@ -9,6 +9,8 @@ if [[ "$(detect_os)" != "macos" ]]; then
   return 0 2>/dev/null || exit 0
 fi
 
+DESCRIPTION="macOS automation with Lua scripting"
+MACOS_ONLY=true
 DEPS=()
 
 setup() {

--- a/hammerspoon/deps.sh
+++ b/hammerspoon/deps.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Dependencies for hammerspoon (macOS only)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../lib/common.sh"
+
+if [[ "$(detect_os)" != "macos" ]]; then
+  log_warn "hammerspoon is macOS-only, skipping on Linux"
+  return 0 2>/dev/null || exit 0
+fi
+
+DEPS=()
+
+setup() {
+  log_info "Installing Hammerspoon via brew cask..."
+  install_cask hammerspoon
+}

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Dotfiles bootstrap installer
-# Usage: ./install.sh [--uninstall|--restow] [package ...]
+# Usage: ./install.sh [--help|--check|--uninstall|--restow] [package ...]
 # No args: interactive menu
 
 set -euo pipefail
@@ -8,13 +8,15 @@ set -euo pipefail
 DOTFILES_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$DOTFILES_DIR/lib/common.sh"
 
-MODE="install"  # install | uninstall | restow
+MODE="install"  # install | uninstall | restow | check | help
 
 # Parse flags
 while [[ "${1:-}" == --* ]]; do
   case "$1" in
     --uninstall) MODE="uninstall"; shift ;;
     --restow)   MODE="restow"; shift ;;
+    --check)    MODE="check"; shift ;;
+    --help|-h)  MODE="help"; shift ;;
     *)           log_error "Unknown flag: $1"; exit 1 ;;
   esac
 done
@@ -184,7 +186,98 @@ print_summary() {
   echo ""
 }
 
+show_help() {
+  echo "Dotfiles Bootstrap Installer"
+  echo ""
+  echo "Usage: ./install.sh [flags] [package ...]"
+  echo ""
+  echo "Flags:"
+  echo "  --help, -h     Show this help message"
+  echo "  --check        Check which deps are installed vs missing"
+  echo "  --uninstall    Unstow selected packages"
+  echo "  --restow       Restow selected packages"
+  echo ""
+  echo "Examples:"
+  echo "  ./install.sh                 # Interactive menu"
+  echo "  ./install.sh tmux zsh        # Install specific packages"
+  echo "  ./install.sh --check         # Check all packages"
+  echo "  ./install.sh --check nvim    # Check nvim deps only"
+  echo "  ./install.sh --uninstall zsh # Unstow zsh"
+  echo ""
+  echo "Available packages:"
+  local pkg
+  while IFS= read -r pkg; do
+    local desc
+    desc="$(get_pkg_description "$pkg")"
+    printf "  %-15s %s\n" "$pkg" "$desc"
+  done < <(available_packages)
+}
+
+check_packages() {
+  local packages=("$@")
+  if [[ ${#packages[@]} -eq 0 ]]; then
+    mapfile -t packages < <(available_packages)
+  fi
+
+  local any_missing=0
+  for pkg in "${packages[@]}"; do
+    local deps_file="$DOTFILES_DIR/$pkg/deps.sh"
+    if [[ ! -d "$DOTFILES_DIR/$pkg" ]]; then
+      log_error "Package '$pkg' not found"
+      any_missing=1
+      continue
+    fi
+    if [[ ! -f "$deps_file" ]]; then
+      log_info "$pkg: no deps.sh"
+      continue
+    fi
+
+    # Source deps.sh to get DEPS array
+    (
+      source "$deps_file"
+      if ! declare -p DEPS &>/dev/null 2>&1; then
+        echo "  $pkg: no DEPS defined"
+        exit 0
+      fi
+      local missing=() installed=()
+      for dep in "${DEPS[@]}"; do
+        if command -v "$dep" &>/dev/null; then
+          installed+=("$dep")
+        else
+          missing+=("$dep")
+        fi
+      done
+      if [[ ${#missing[@]} -eq 0 ]]; then
+        printf "  ${GREEN}✔${NC}  %s — all deps installed (%s)\n" "$pkg" "${installed[*]}"
+      else
+        printf "  ${YELLOW}⚠${NC}  %s — missing: %s" "$pkg" "${missing[*]}"
+        if [[ ${#installed[@]} -gt 0 ]]; then
+          printf ", installed: %s" "${installed[*]}"
+        fi
+        printf "\n"
+        exit 1
+      fi
+    ) || any_missing=1
+    unset DEPS DESCRIPTION MACOS_ONLY 2>/dev/null || true
+    unset -f setup 2>/dev/null || true
+  done
+
+  return "$any_missing"
+}
+
 main() {
+  if [[ "$MODE" == "help" ]]; then
+    show_help
+    exit 0
+  fi
+
+  if [[ "$MODE" == "check" ]]; then
+    log_info "Checking dependencies ($(detect_os), $(detect_pkg_manager))"
+    echo ""
+    check_packages "$@"
+    exit $?
+  fi
+
   log_info "Dotfiles installer ($(detect_os), $(detect_pkg_manager))"
   ensure_stow
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Dotfiles bootstrap installer
+# Usage: ./install.sh [--uninstall|--restow] [package ...]
+# No args: interactive menu
+
+set -euo pipefail
+
+DOTFILES_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$DOTFILES_DIR/lib/common.sh"
+
+MODE="install"  # install | uninstall | restow
+
+# Parse flags
+while [[ "${1:-}" == --* ]]; do
+  case "$1" in
+    --uninstall) MODE="uninstall"; shift ;;
+    --restow)   MODE="restow"; shift ;;
+    *)           log_error "Unknown flag: $1"; exit 1 ;;
+  esac
+done
+
+# Discover available packages (dirs containing a stow-style dotfile tree)
+available_packages() {
+  local pkg
+  for pkg in "$DOTFILES_DIR"/*/; do
+    pkg="$(basename "$pkg")"
+    [[ "$pkg" == "lib" ]] && continue
+    echo "$pkg"
+  done
+}
+
+# Interactive menu when no args given
+select_packages() {
+  local packages=()
+  mapfile -t packages < <(available_packages)
+  log_info "Available packages:"
+  PS3="Enter numbers (space-separated) or 'a' for all: "
+  select pkg in "${packages[@]}" "ALL"; do
+    if [[ "$pkg" == "ALL" || "$REPLY" == "a" ]]; then
+      SELECTED=("${packages[@]}")
+    else
+      SELECTED=("$pkg")
+    fi
+    break
+  done
+}
+
+run_stow() {
+  local pkg="$1"
+  case "$MODE" in
+    install)   stow -v -d "$DOTFILES_DIR" -t "$HOME" "$pkg" ;;
+    uninstall) stow -v -D -d "$DOTFILES_DIR" -t "$HOME" "$pkg" ;;
+    restow)    stow -v -R -d "$DOTFILES_DIR" -t "$HOME" "$pkg" ;;
+  esac
+}
+
+process_package() {
+  local pkg="$1"
+  local deps_file="$DOTFILES_DIR/$pkg/deps.sh"
+
+  log_info "Processing package: $pkg ($MODE)"
+
+  if [[ "$MODE" == "uninstall" ]]; then
+    run_stow "$pkg"
+    log_success "Unstowed $pkg"
+    return
+  fi
+
+  # Source deps.sh if it exists
+  if [[ -f "$deps_file" ]]; then
+    log_info "Sourcing $pkg/deps.sh..."
+    (
+      source "$deps_file"
+      # Install system dependencies
+      if declare -p DEPS &>/dev/null 2>&1; then
+        for dep in "${DEPS[@]}"; do
+          if ! command -v "$dep" &>/dev/null; then
+            log_info "Installing dependency: $dep"
+            install_pkg "$dep"
+          else
+            log_success "Dependency already installed: $dep"
+          fi
+        done
+      fi
+      # Run setup function if defined
+      if declare -f setup &>/dev/null; then
+        log_info "Running setup for $pkg..."
+        setup
+      fi
+    )
+  fi
+
+  run_stow "$pkg"
+  log_success "Stowed $pkg"
+}
+
+main() {
+  log_info "Dotfiles installer ($(detect_os), $(detect_pkg_manager))"
+  ensure_stow
+
+  local SELECTED=()
+
+  if [[ $# -gt 0 ]]; then
+    SELECTED=("$@")
+  else
+    select_packages
+  fi
+
+  for pkg in "${SELECTED[@]}"; do
+    if [[ ! -d "$DOTFILES_DIR/$pkg" ]]; then
+      log_warn "Package '$pkg' not found, skipping"
+      continue
+    fi
+    process_package "$pkg"
+  done
+
+  log_success "Done!"
+}
+
+main "$@"

--- a/install.sh
+++ b/install.sh
@@ -157,8 +157,31 @@ process_package() {
 
   if [[ ${#dep_failures[@]} -gt 0 ]]; then
     log_warn "Package '$pkg' had failures: ${dep_failures[*]}"
+    LAST_PKG_FAILURES="${dep_failures[*]}"
     return 1
   fi
+  LAST_PKG_FAILURES=""
+}
+
+print_summary() {
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  Summary"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+
+  local pkg
+  for pkg in "${SUMMARY_SUCCESS[@]:-}"; do
+    [[ -n "$pkg" ]] && printf "  ${GREEN}✔${NC}  %s\n" "$pkg"
+  done
+  for pkg in "${SUMMARY_WARN[@]:-}"; do
+    [[ -n "$pkg" ]] && printf "  ${YELLOW}⚠${NC}  %s — failures: %s\n" "$pkg" "${SUMMARY_WARN_DETAILS[$pkg]:-unknown}"
+  done
+  for pkg in "${SUMMARY_FAIL[@]:-}"; do
+    [[ -n "$pkg" ]] && printf "  ${RED}✘${NC}  %s — %s\n" "$pkg" "${SUMMARY_FAIL_DETAILS[$pkg]:-failed}"
+  done
+
+  echo ""
 }
 
 main() {
@@ -173,22 +196,36 @@ main() {
     select_packages
   fi
 
+  # Summary tracking arrays
+  SUMMARY_SUCCESS=()
+  SUMMARY_WARN=()
+  SUMMARY_FAIL=()
+  declare -A SUMMARY_WARN_DETAILS
+  declare -A SUMMARY_FAIL_DETAILS
   local any_failures=0
 
   for pkg in "${SELECTED[@]}"; do
     if [[ ! -d "$DOTFILES_DIR/$pkg" ]]; then
       log_warn "Package '$pkg' not found, skipping"
+      SUMMARY_FAIL+=("$pkg")
+      SUMMARY_FAIL_DETAILS["$pkg"]="not found"
+      any_failures=1
       continue
     fi
     if ! process_package "$pkg"; then
+      # Package had some dep/setup failures but stow still ran
+      SUMMARY_WARN+=("$pkg")
+      SUMMARY_WARN_DETAILS["$pkg"]="${LAST_PKG_FAILURES:-unknown}"
       any_failures=1
+    else
+      SUMMARY_SUCCESS+=("$pkg")
     fi
   done
 
+  print_summary
+
   if [[ "$any_failures" -eq 1 ]]; then
-    log_warn "Done with some failures (see above)"
-  else
-    log_success "Done!"
+    exit 1
   fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ source "$DOTFILES_DIR/lib/common.sh"
 MODE="install"  # install | uninstall | restow | check | help
 
 # Parse flags
-while [[ "${1:-}" == --* ]]; do
+while [[ "${1:-}" == -* ]]; do
   case "$1" in
     --uninstall) MODE="uninstall"; shift ;;
     --restow)   MODE="restow"; shift ;;
@@ -123,7 +123,7 @@ process_package() {
     source "$deps_file"
 
     # Install system dependencies
-    if declare -p DEPS &>/dev/null 2>&1; then
+    if declare -p DEPS &>/dev/null; then
       for dep in "${DEPS[@]}"; do
         if ! command -v "$dep" &>/dev/null; then
           log_info "Installing dependency: $dep"
@@ -235,7 +235,7 @@ check_packages() {
     # Source deps.sh to get DEPS array
     (
       source "$deps_file"
-      if ! declare -p DEPS &>/dev/null 2>&1; then
+      if ! declare -p DEPS &>/dev/null; then
         echo "  $pkg: no DEPS defined"
         exit 0
       fi

--- a/install.sh
+++ b/install.sh
@@ -97,9 +97,9 @@ select_packages() {
 run_stow() {
   local pkg="$1"
   case "$MODE" in
-    install)   stow -v -d "$DOTFILES_DIR" -t "$HOME" "$pkg" ;;
-    uninstall) stow -v -D -d "$DOTFILES_DIR" -t "$HOME" "$pkg" ;;
-    restow)    stow -v -R -d "$DOTFILES_DIR" -t "$HOME" "$pkg" ;;
+    install)   stow -v --ignore='deps\.sh' -d "$DOTFILES_DIR" -t "$HOME" "$pkg" ;;
+    uninstall) stow -v --ignore='deps\.sh' -D -d "$DOTFILES_DIR" -t "$HOME" "$pkg" ;;
+    restow)    stow -v --ignore='deps\.sh' -R -d "$DOTFILES_DIR" -t "$HOME" "$pkg" ;;
   esac
 }
 

--- a/install.sh
+++ b/install.sh
@@ -113,32 +113,52 @@ process_package() {
     return
   fi
 
+  local dep_failures=()
+
   # Source deps.sh if it exists
   if [[ -f "$deps_file" ]]; then
     log_info "Sourcing $pkg/deps.sh..."
-    (
-      source "$deps_file"
-      # Install system dependencies
-      if declare -p DEPS &>/dev/null 2>&1; then
-        for dep in "${DEPS[@]}"; do
-          if ! command -v "$dep" &>/dev/null; then
-            log_info "Installing dependency: $dep"
-            install_pkg "$dep"
-          else
-            log_success "Dependency already installed: $dep"
+    source "$deps_file"
+
+    # Install system dependencies
+    if declare -p DEPS &>/dev/null 2>&1; then
+      for dep in "${DEPS[@]}"; do
+        if ! command -v "$dep" &>/dev/null; then
+          log_info "Installing dependency: $dep"
+          if ! install_pkg "$dep"; then
+            local mgr
+            mgr="$(detect_pkg_manager)"
+            log_error "Failed to install dep '$dep' via $mgr for package '$pkg'"
+            dep_failures+=("$dep")
           fi
-        done
+        else
+          log_success "Dependency already installed: $dep"
+        fi
+      done
+    fi
+
+    # Run setup function if defined (even if some deps failed)
+    if declare -f setup &>/dev/null; then
+      log_info "Running setup for $pkg..."
+      if ! setup; then
+        log_error "Setup failed for package '$pkg'"
+        dep_failures+=("setup()")
       fi
-      # Run setup function if defined
-      if declare -f setup &>/dev/null; then
-        log_info "Running setup for $pkg..."
-        setup
-      fi
-    )
+    fi
+
+    # Clean up sourced variables/functions to avoid leaking between packages
+    unset DEPS DESCRIPTION MACOS_ONLY 2>/dev/null || true
+    unset -f setup 2>/dev/null || true
   fi
 
+  # Stow even if deps failed
   run_stow "$pkg"
   log_success "Stowed $pkg"
+
+  if [[ ${#dep_failures[@]} -gt 0 ]]; then
+    log_warn "Package '$pkg' had failures: ${dep_failures[*]}"
+    return 1
+  fi
 }
 
 main() {
@@ -153,15 +173,23 @@ main() {
     select_packages
   fi
 
+  local any_failures=0
+
   for pkg in "${SELECTED[@]}"; do
     if [[ ! -d "$DOTFILES_DIR/$pkg" ]]; then
       log_warn "Package '$pkg' not found, skipping"
       continue
     fi
-    process_package "$pkg"
+    if ! process_package "$pkg"; then
+      any_failures=1
+    fi
   done
 
-  log_success "Done!"
+  if [[ "$any_failures" -eq 1 ]]; then
+    log_warn "Done with some failures (see above)"
+  else
+    log_success "Done!"
+  fi
 }
 
 main "$@"

--- a/install.sh
+++ b/install.sh
@@ -19,30 +19,77 @@ while [[ "${1:-}" == --* ]]; do
   esac
 done
 
-# Discover available packages (dirs containing a stow-style dotfile tree)
+# Get description for a package from its deps.sh
+get_pkg_description() {
+  local pkg="$1"
+  local deps_file="$DOTFILES_DIR/$pkg/deps.sh"
+  if [[ -f "$deps_file" ]]; then
+    local desc
+    desc="$(grep '^DESCRIPTION=' "$deps_file" | head -1 | sed 's/^DESCRIPTION="//' | sed 's/"$//')"
+    echo "${desc:-No description}"
+  else
+    echo "No description"
+  fi
+}
+
+# Check if a package is macOS-only
+is_macos_only() {
+  local pkg="$1"
+  local deps_file="$DOTFILES_DIR/$pkg/deps.sh"
+  [[ -f "$deps_file" ]] && grep -q '^MACOS_ONLY=true' "$deps_file"
+}
+
+# Discover available packages, filtered by OS
 available_packages() {
-  local pkg
+  local pkg current_os
+  current_os="$(detect_os)"
   for pkg in "$DOTFILES_DIR"/*/; do
     pkg="$(basename "$pkg")"
     [[ "$pkg" == "lib" ]] && continue
+    # Hide macOS-only packages on Linux
+    if [[ "$current_os" != "macos" ]] && is_macos_only "$pkg"; then
+      continue
+    fi
     echo "$pkg"
   done
 }
 
 # Interactive menu when no args given
 select_packages() {
-  local packages=()
+  local packages=() descriptions=()
   mapfile -t packages < <(available_packages)
+
+  echo ""
   log_info "Available packages:"
-  PS3="Enter numbers (space-separated) or 'a' for all: "
-  select pkg in "${packages[@]}" "ALL"; do
-    if [[ "$pkg" == "ALL" || "$REPLY" == "a" ]]; then
-      SELECTED=("${packages[@]}")
-    else
-      SELECTED=("$pkg")
-    fi
-    break
+  echo ""
+  local i
+  for i in "${!packages[@]}"; do
+    local desc
+    desc="$(get_pkg_description "${packages[$i]}")"
+    printf "  %s) %s — %s\n" "$((i + 1))" "${packages[$i]}" "$desc"
   done
+  echo ""
+  printf "Enter numbers (space-separated) or 'a' for all: "
+  read -r reply
+
+  if [[ "$reply" == "a" || "$reply" == "A" ]]; then
+    SELECTED=("${packages[@]}")
+  else
+    SELECTED=()
+    for num in $reply; do
+      local idx=$((num - 1))
+      if [[ $idx -ge 0 && $idx -lt ${#packages[@]} ]]; then
+        SELECTED+=("${packages[$idx]}")
+      else
+        log_warn "Invalid selection: $num"
+      fi
+    done
+  fi
+
+  if [[ ${#SELECTED[@]} -eq 0 ]]; then
+    log_error "No packages selected"
+    exit 1
+  fi
 }
 
 run_stow() {

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Shared helpers for dotfiles bootstrap
+
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info()    { printf "${BLUE}[INFO]${NC} %s\n" "$*"; }
+log_success() { printf "${GREEN}[OK]${NC} %s\n" "$*"; }
+log_warn()    { printf "${YELLOW}[WARN]${NC} %s\n" "$*"; }
+log_error()   { printf "${RED}[ERROR]${NC} %s\n" "$*" >&2; }
+
+detect_os() {
+  case "$(uname -s)" in
+    Darwin) echo "macos" ;;
+    Linux)  echo "linux" ;;
+    *)      echo "unknown" ;;
+  esac
+}
+
+detect_pkg_manager() {
+  if command -v brew &>/dev/null; then echo "brew"
+  elif command -v apt &>/dev/null; then echo "apt"
+  elif command -v dnf &>/dev/null; then echo "dnf"
+  elif command -v pacman &>/dev/null; then echo "pacman"
+  else echo "unknown"
+  fi
+}
+
+install_pkg() {
+  local pkg="$1"
+  local mgr
+  mgr="$(detect_pkg_manager)"
+
+  case "$mgr" in
+    brew)   brew install "$pkg" ;;
+    apt)    sudo apt install -y "$pkg" ;;
+    dnf)    sudo dnf install -y "$pkg" ;;
+    pacman) sudo pacman -S --noconfirm "$pkg" ;;
+    *)      log_error "Unknown package manager"; return 1 ;;
+  esac
+}
+
+install_cask() {
+  brew install --cask "$1"
+}
+
+ensure_stow() {
+  if ! command -v stow &>/dev/null; then
+    log_info "Installing GNU Stow..."
+    install_pkg stow
+  fi
+}

--- a/nvim/.config/nvim/lua/plugins/lsp.lua
+++ b/nvim/.config/nvim/lua/plugins/lsp.lua
@@ -21,7 +21,8 @@ return {
     "williamboman/mason-lspconfig.nvim",
     config = function()
       require("mason-lspconfig").setup({
-        ensure_installed = lsp_servers
+        ensure_installed = lsp_servers,
+        automatic_enable = false,
       })
     end
   },

--- a/nvim/deps.sh
+++ b/nvim/deps.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Neovim package dependencies
+
+# Package names vary by OS/package manager
+_os="$(detect_os)"
+_mgr="$(detect_pkg_manager)"
+
+DEPS=(git ripgrep make python3 node npm)
+
+# Add OS-specific package names
+if [[ "$_mgr" == "brew" ]]; then
+  DEPS+=(neovim fd gcc stylua prettier)
+elif [[ "$_mgr" == "apt" ]]; then
+  DEPS+=(neovim fd-find gcc python3-pip stylua prettier)
+elif [[ "$_mgr" == "dnf" ]]; then
+  DEPS+=(neovim fd-find gcc python3-pip stylua prettier)
+elif [[ "$_mgr" == "pacman" ]]; then
+  DEPS+=(neovim fd gcc python3-pip stylua prettier)
+fi
+
+setup() {
+  # Run headless Lazy sync to install plugins
+  log_info "Running Neovim headless Lazy sync..."
+  nvim --headless '+Lazy! sync' +qa 2>/dev/null || true
+  log_success "Neovim plugins synced"
+}

--- a/nvim/deps.sh
+++ b/nvim/deps.sh
@@ -10,14 +10,15 @@ _mgr="$(detect_pkg_manager)"
 DEPS=(git ripgrep make python3 node npm)
 
 # Add OS-specific package names
+# Note: stylua and prettier are handled by Mason inside Neovim, not system packages
 if [[ "$_mgr" == "brew" ]]; then
-  DEPS+=(neovim fd gcc stylua prettier)
+  DEPS+=(neovim fd gcc)
 elif [[ "$_mgr" == "apt" ]]; then
-  DEPS+=(neovim fd-find gcc python3-pip stylua prettier)
+  DEPS+=(neovim fd-find gcc python3-pip build-essential)
 elif [[ "$_mgr" == "dnf" ]]; then
-  DEPS+=(neovim fd-find gcc python3-pip stylua prettier)
+  DEPS+=(neovim fd-find gcc python3-pip)
 elif [[ "$_mgr" == "pacman" ]]; then
-  DEPS+=(neovim fd gcc python3-pip stylua prettier)
+  DEPS+=(neovim fd gcc python3-pip)
 fi
 
 setup() {

--- a/nvim/deps.sh
+++ b/nvim/deps.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Neovim package dependencies
 
+DESCRIPTION="Neovim editor with LSP, treesitter, telescope"
+
 # Package names vary by OS/package manager
 _os="$(detect_os)"
 _mgr="$(detect_pkg_manager)"

--- a/nvim/deps.sh
+++ b/nvim/deps.sh
@@ -45,7 +45,8 @@ install_nvim_appimage() {
 
   # Extract instead of running directly — avoids FUSE dependency on servers
   log_info "Extracting AppImage (no FUSE required)..."
-  cd "$tmpdir" && ./nvim.appimage --appimage-extract >/dev/null 2>&1
+  (cd "$tmpdir" && ./nvim.appimage --appimage-extract >/dev/null 2>&1)
+  mkdir -p "$HOME/.local/lib"
   rm -rf "$HOME/.local/lib/nvim-squashfs"
   mv "$tmpdir/squashfs-root" "$HOME/.local/lib/nvim-squashfs"
   ln -sf "$HOME/.local/lib/nvim-squashfs/usr/bin/nvim" "$target"

--- a/nvim/deps.sh
+++ b/nvim/deps.sh
@@ -7,21 +7,47 @@ DESCRIPTION="Neovim editor with LSP, treesitter, telescope"
 _os="$(detect_os)"
 _mgr="$(detect_pkg_manager)"
 
-DEPS=(git ripgrep make python3 node npm)
+DEPS=(git ripgrep make python3 node npm curl)
 
 # Add OS-specific package names
 # Note: stylua and prettier are handled by Mason inside Neovim, not system packages
+# Note: neovim is installed via AppImage on Linux (apt/dnf/pacman ship outdated versions)
 if [[ "$_mgr" == "brew" ]]; then
   DEPS+=(neovim fd gcc)
 elif [[ "$_mgr" == "apt" ]]; then
-  DEPS+=(neovim fd-find gcc python3-pip build-essential)
+  DEPS+=(fd-find gcc python3-pip build-essential)
 elif [[ "$_mgr" == "dnf" ]]; then
-  DEPS+=(neovim fd-find gcc python3-pip)
+  DEPS+=(fd-find gcc python3-pip)
 elif [[ "$_mgr" == "pacman" ]]; then
-  DEPS+=(neovim fd gcc python3-pip)
+  DEPS+=(fd gcc python3-pip)
 fi
 
+install_nvim_appimage() {
+  local target="$HOME/.local/bin/nvim"
+  mkdir -p "$HOME/.local/bin"
+
+  # Skip if nvim is already 0.11+
+  if command -v nvim &>/dev/null; then
+    local ver
+    ver="$(nvim --version | head -1 | grep -oP 'v\K[0-9]+\.[0-9]+')"
+    if [[ "$(printf '%s\n' "0.11" "$ver" | sort -V | head -1)" == "0.11" ]]; then
+      log_info "Neovim $ver already installed, skipping AppImage download"
+      return 0
+    fi
+  fi
+
+  log_info "Downloading latest Neovim AppImage..."
+  curl -fsSL -o "$target" https://github.com/neovim/neovim/releases/latest/download/nvim-linux-x86_64.appimage
+  chmod u+x "$target"
+  log_success "Neovim AppImage installed to $target"
+}
+
 setup() {
+  # Install Neovim via AppImage on Linux
+  if [[ "$_os" != "macos" ]]; then
+    install_nvim_appimage
+  fi
+
   # Run headless Lazy sync to install plugins
   log_info "Running Neovim headless Lazy sync..."
   nvim --headless '+Lazy! sync' +qa 2>/dev/null || true

--- a/nvim/deps.sh
+++ b/nvim/deps.sh
@@ -36,10 +36,22 @@ install_nvim_appimage() {
     fi
   fi
 
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+
   log_info "Downloading latest Neovim AppImage..."
-  curl -fsSL -o "$target" https://github.com/neovim/neovim/releases/latest/download/nvim-linux-x86_64.appimage
-  chmod u+x "$target"
-  log_success "Neovim AppImage installed to $target"
+  curl -fsSL -o "$tmpdir/nvim.appimage" https://github.com/neovim/neovim/releases/latest/download/nvim-linux-x86_64.appimage
+  chmod u+x "$tmpdir/nvim.appimage"
+
+  # Extract instead of running directly — avoids FUSE dependency on servers
+  log_info "Extracting AppImage (no FUSE required)..."
+  cd "$tmpdir" && ./nvim.appimage --appimage-extract >/dev/null 2>&1
+  rm -rf "$HOME/.local/lib/nvim-squashfs"
+  mv "$tmpdir/squashfs-root" "$HOME/.local/lib/nvim-squashfs"
+  ln -sf "$HOME/.local/lib/nvim-squashfs/usr/bin/nvim" "$target"
+  rm -rf "$tmpdir"
+
+  log_success "Neovim installed to $target"
 }
 
 setup() {

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -70,8 +70,8 @@ bind % split-window -h -c "#{pane_current_path}"
 
 
 ### Plugins ###
-if "test ! -d ~/dotfiles/tmux/plugins/tpm" \
-   "run 'git clone https://github.com/tmux-plugins/tpm ~/dotfiles/tmux/plugins/tpm' && ~/.tmux/plugins/tpm/bin/install_plugins'"
+if "test ! -d ~/.tmux/plugins/tpm" \
+   "run 'git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm && ~/.tmux/plugins/tpm/bin/install_plugins'"
 
 # Configure the catppuccin plugin
 set -g @catppuccin_flavor "mocha"
@@ -94,4 +94,4 @@ set -g @plugin 'tmux-plugins/tmux-cpu'
 set -g @plugin 'christoomey/vim-tmux-navigator'
 
 # Check tpm exists before installing
-if '[ -f ~/.dotfiles/tmux/plugins/tpm/tpm ]' 'run-shell ~/.dotfiles/tmux/plugins/tpm/tpm' 'display-message "TPM not found, skipping plugin load"'
+if '[ -f ~/.tmux/plugins/tpm/tpm ]' 'run-shell ~/.tmux/plugins/tpm/tpm' 'display-message "TPM not found, skipping plugin load"'

--- a/tmux/deps.sh
+++ b/tmux/deps.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Dependency manifest for tmux package
 
+DESCRIPTION="Terminal multiplexer with TPM plugin manager"
 DEPS=(tmux git)
 
 setup() {

--- a/tmux/deps.sh
+++ b/tmux/deps.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Dependency manifest for tmux package
+
+DEPS=(tmux git)
+
+setup() {
+    local tpm_dir="$HOME/.tmux/plugins/tpm"
+    if [ ! -d "$tpm_dir" ]; then
+        log_info "Installing TPM..."
+        git clone https://github.com/tmux-plugins/tpm "$tpm_dir"
+    fi
+
+    if [ -x "$tpm_dir/bin/install_plugins" ]; then
+        log_info "Installing tmux plugins via TPM..."
+        "$tpm_dir/bin/install_plugins"
+    fi
+}

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -1,5 +1,5 @@
 # Load secrets
-source ~/.secrets
+[[ -f ~/.secrets ]] && source ~/.secrets
 
 # Speeding up omz
 DISABLE_AUTO_UPDATE="true"

--- a/zsh/deps.sh
+++ b/zsh/deps.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# ZSH package dependencies
+
+DEPS=(zsh fzf)
+
+setup() {
+  local ZSH_DIR="${HOME}/.oh-my-zsh"
+  local ZSH_CUSTOM="${ZSH_DIR}/custom"
+
+  # Install oh-my-zsh if not present
+  if [[ ! -d "$ZSH_DIR" ]]; then
+    log_info "Installing oh-my-zsh..."
+    RUNZSH=no KEEP_ZSHRC=yes sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+  else
+    log_info "oh-my-zsh already installed"
+  fi
+
+  # Clone zsh-autosuggestions
+  local auto_dir="${ZSH_CUSTOM}/plugins/zsh-autosuggestions"
+  if [[ ! -d "$auto_dir" ]]; then
+    log_info "Installing zsh-autosuggestions..."
+    git clone https://github.com/zsh-users/zsh-autosuggestions "$auto_dir"
+  else
+    log_info "zsh-autosuggestions already installed"
+  fi
+
+  # Clone zsh-syntax-highlighting
+  local syntax_dir="${ZSH_CUSTOM}/plugins/zsh-syntax-highlighting"
+  if [[ ! -d "$syntax_dir" ]]; then
+    log_info "Installing zsh-syntax-highlighting..."
+    git clone https://github.com/zsh-users/zsh-syntax-highlighting "$syntax_dir"
+  else
+    log_info "zsh-syntax-highlighting already installed"
+  fi
+
+  # Install nvm
+  if [[ ! -d "${HOME}/.nvm" ]]; then
+    log_info "Installing nvm..."
+    PROFILE=/dev/null bash -c "$(curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh)"
+  else
+    log_info "nvm already installed"
+  fi
+}

--- a/zsh/deps.sh
+++ b/zsh/deps.sh
@@ -41,4 +41,13 @@ setup() {
   else
     log_info "nvm already installed"
   fi
+
+  # Ensure ~/.secrets exists (sourced by .zshrc)
+  [[ -f "$HOME/.secrets" ]] || touch "$HOME/.secrets"
+
+  # Back up any existing .zshrc so stow can create symlink
+  if [[ -f "$HOME/.zshrc" && ! -L "$HOME/.zshrc" ]]; then
+    log_warn "Backing up existing ~/.zshrc to ~/.zshrc.bak"
+    mv "$HOME/.zshrc" "$HOME/.zshrc.bak"
+  fi
 }

--- a/zsh/deps.sh
+++ b/zsh/deps.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # ZSH package dependencies
 
+DESCRIPTION="Zsh shell with oh-my-zsh, autosuggestions, syntax highlighting, nvm"
 DEPS=(zsh fzf)
 
 setup() {


### PR DESCRIPTION
## Summary

Automated dotfiles installer — clone the repo, pick your packages, and everything works. No more manually installing dependencies or remembering setup steps.

- **One-liner install** from any machine: `curl -fsSL https://raw.githubusercontent.com/mudmov/dotfiles/main/bootstrap.sh | bash`
- **Interactive menu** with descriptions when run with no args, or pass package names directly: `./install.sh nvim tmux zsh`
- **Selective install** — only installs what you pick. macOS-only packages (aerospace, ghostty, hammerspoon) hidden on Linux
- **Dependency management** — each package declares its deps in `deps.sh`; the script installs them via the right package manager (brew/apt/dnf/pacman)
- **Post-install setup** — oh-my-zsh + plugins, TPM + tmux plugins, Lazy.nvim headless sync, all automated
- **Cross-platform** — macOS and Linux (Ubuntu/Fedora/Arch)
- **Resilient** — failed deps don't block the rest; clear error logging; summary report at the end
- **Utility flags** — `--help`, `--check` (audit deps without installing), `--uninstall`, `--restow`

## New files

| File | Purpose |
|------|---------|
| `bootstrap.sh` | curl one-liner entry point — clones repo and runs install.sh |
| `install.sh` | Main installer — menu, dep install, setup, stow, summary |
| `lib/common.sh` | Shared helpers — OS detection, package manager abstraction, logging |
| `*/deps.sh` | Per-package dependency manifests (DEPS array + setup function) |

## Usage

```bash
# Remote one-liner
curl -fsSL https://raw.githubusercontent.com/mudmov/dotfiles/main/bootstrap.sh | bash

# Or clone and run
git clone git@github.com:mudmov/dotfiles.git ~/dotfiles
cd ~/dotfiles
./install.sh              # interactive menu
./install.sh nvim tmux    # specific packages
./install.sh --check      # audit deps
./install.sh --help       # usage info
```

## Test plan

- [ ] `./install.sh --help` — shows usage, flags, package list with descriptions
- [ ] `./install.sh --check nvim` — shows installed vs missing deps
- [ ] `./install.sh` — interactive menu shows all packages with descriptions
- [ ] `./install.sh tmux` — installs only tmux + deps + stow
- [ ] `./install.sh --uninstall tmux` — removes symlinks
- [ ] `./install.sh --restow tmux` — re-links
- [ ] Summary report prints at end with green/yellow/red status per package
- [ ] On Linux: macOS-only packages hidden from menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)